### PR TITLE
Update grupo.cpp

### DIFF
--- a/tarea1/src/grupo.cpp
+++ b/tarea1/src/grupo.cpp
@@ -86,3 +86,10 @@ void imprimirPersonasFecha(TGrupo grupo, TFecha fecha){
 
     /****** Fin de parte Parte 5.5 *****/ 
 }
+void liberarTGrupo(TGrupo& grupo){
+    for(nat i =0; i < grupo->tope; i++){
+        liberarTPersona(grupo->personas[i]);
+    }
+    delete grupo;
+    grupo = NULL;
+}


### PR DESCRIPTION
> ==9993== Invalid read of size 8
> ==9993==    at 0x10A969: agregarAGrupo(rep_grupo*&, rep_persona*) (grupo.cpp:22)
> ==9993==    by 0x109FEC: main_agregarAGrupo(rep_grupo*&, rep_persona*&) (principal.cpp:316)
> ==9993==    by 0x109674: main (principal.cpp:151)
> ==9993==  Address 0x804e260f8 is not stack'd, malloc'd or (recently) free'd
> ==9993== 
> ==9993== 
> ==9993== Process terminating with default action of signal 11 (SIGSEGV)
> ==9993==  Access not within mapped region at address 0x804E260F8
> ==9993==    at 0x10A969: agregarAGrupo(rep_grupo*&, rep_persona*) (grupo.cpp:22)
> ==9993==    by 0x109FEC: main_agregarAGrupo(rep_grupo*&, rep_persona*&) (principal.cpp:316)
> ==9993==    by 0x109674: main (principal.cpp:151)
> ==9993==  If you believe this happened as a result of a stack
> ==9993==  overflow in your program's main thread (unlikely but
> ==9993==  possible), you can try to increase the size of the
> ==9993==  main thread stack using the --main-stacksize= flag.
> ==9993==  The main thread stack size used in this run was 8388608.
> timeout: the monitored command dumped core
